### PR TITLE
对原有NSArray/NSSet/NSDictionary分类进行优化

### DIFF
--- a/NSArray+HYBUnicodeReadable.h
+++ b/NSArray+HYBUnicodeReadable.h
@@ -1,0 +1,23 @@
+//
+//  NSArray+HYBUnicodeReadable.h
+//  demo
+//
+//  Created by huangyibiao on 15/12/29.
+//  Copyright © 2015年 huangyibiao. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+/*!
+ *  @author 黄仪标, 16-12-29 10:12:52
+ *
+ *  请不要删除作者信息
+ *
+ *  @blog article http://www.henishuo.com/ios-unicode-readable/
+ *  @github https://github.com/CoderJackyHuang/HYBUnicodeReadable
+ *  @email huangyibiao520@163.com
+ *  @sinaweibo 标哥Jacky
+ */
+@interface NSArray (HYBUnicodeReadable)
+
+@end

--- a/NSArray+HYBUnicodeReadable.m
+++ b/NSArray+HYBUnicodeReadable.m
@@ -1,0 +1,91 @@
+//
+//  NSArray+HYBUnicodeReadable.m
+//  demo
+//
+//  Created by huangyibiao on 15/12/29.
+//  Copyright © 2015年 huangyibiao. All rights reserved.
+//
+
+#import "NSArray+HYBUnicodeReadable.h"
+
+@implementation NSArray (HYBUnicodeReadable)
+
+#if DEBUG
+
+- (NSString *)descriptionWithLocale:(id)locale indent:(NSUInteger)level
+{
+    NSMutableString *desc = [NSMutableString string];
+    NSMutableString *tabString = [[NSMutableString alloc] initWithCapacity:level];
+    
+    for (NSUInteger i = 0; i < level; ++i) {
+        [tabString appendString:@"\t"];
+    }
+    
+    NSString *tab = (level > 0) ? tabString : @"";
+    
+    [desc appendString:@"(\n"];
+    
+    for (int i = 0; i < self.count; i++)
+    {
+        id obj = self[i];
+        
+        if ([obj isKindOfClass:[NSDictionary class]]
+            || [obj isKindOfClass:[NSArray class]]
+            || [obj isKindOfClass:[NSSet class]])
+        {
+            NSString *str = [((NSDictionary *)obj) descriptionWithLocale:locale indent:level + 1];
+            (i == (self.count - 1)) ? [desc appendFormat:@"%@\t%@\n", tab, str] : [desc appendFormat:@"%@\t%@,\n", tab, str];
+        }
+        else if ([obj isKindOfClass:[NSString class]])
+        {
+            (i == (self.count - 1)) ? [desc appendFormat:@"%@\t\"%@\"\n", tab, obj] : [desc appendFormat:@"%@\t\"%@\",\n", tab, obj];
+        }
+        else if ([obj isKindOfClass:[NSData class]])
+        {
+            // 如果是NSData类型，尝试去解析结果，以打印出可阅读的数据
+            NSError *error = nil;
+            NSObject *result =  [NSJSONSerialization JSONObjectWithData:obj
+                                                                options:NSJSONReadingMutableContainers
+                                                                  error:&error];
+            // 解析成功
+            if (error == nil && result != nil)
+            {
+                if ([result isKindOfClass:[NSDictionary class]]
+                    || [result isKindOfClass:[NSArray class]]
+                    || [result isKindOfClass:[NSSet class]])
+                {
+                    NSString *str = [((NSDictionary *)result) descriptionWithLocale:locale indent:level + 1];
+                    (i == (self.count - 1)) ? [desc appendFormat:@"%@\t%@\n", tab, str] : [desc appendFormat:@"%@\t%@,\n", tab, str];
+                    
+                }
+                else if ([obj isKindOfClass:[NSString class]])
+                {
+                    (i == (self.count - 1)) ? [desc appendFormat:@"%@\t\"%@\"\n", tab, result] : [desc appendFormat:@"%@\t\"%@\",\n", tab, result];
+                }
+            }
+            else {
+                @try {
+                    NSString *str = [[NSString alloc] initWithData:obj encoding:NSUTF8StringEncoding];
+                    if (str != nil) {
+                        (i == (self.count - 1)) ? [desc appendFormat:@"%@\t\"%@\"\n", tab, str] : [desc appendFormat:@"%@\t\"%@\",\n", tab, str];
+                    } else {
+                        (i == (self.count - 1)) ? [desc appendFormat:@"%@\t%@\n", tab, obj] : [desc appendFormat:@"%@\t%@,\n", tab, obj];
+                    }
+                }
+                @catch (NSException *exception) {
+                    (i == (self.count - 1)) ? [desc appendFormat:@"%@\t%@\n", tab, obj] : [desc appendFormat:@"%@\t%@,\n", tab, obj];
+                }
+            }
+        } else {
+            (i == (self.count - 1)) ? [desc appendFormat:@"%@\t%@\n", tab, obj] : [desc appendFormat:@"%@\t%@,\n", tab, obj];
+        }
+    }
+    
+    [desc appendFormat:@"%@)", tab];
+    
+    return desc;
+}
+
+#endif
+
+@end

--- a/NSDictionary+HYBUnicodeReadable.h
+++ b/NSDictionary+HYBUnicodeReadable.h
@@ -1,0 +1,23 @@
+//
+//  NSDictionary+HYBUnicodeReadable.h
+//  demo
+//
+//  Created by huangyibiao on 15/12/29.
+//  Copyright © 2015年 huangyibiao. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+/*!
+ *  @author 黄仪标, 16-12-29 10:12:52
+ *
+ *  请不要删除作者信息
+ *
+ *  @blog article http://www.henishuo.com/ios-unicode-readable/
+ *  @github https://github.com/CoderJackyHuang/HYBUnicodeReadable
+ *  @email huangyibiao520@163.com
+ *  @sinaweibo 标哥Jacky
+ */
+@interface NSDictionary (HYBUnicodeReadable)
+
+@end

--- a/NSDictionary+HYBUnicodeReadable.m
+++ b/NSDictionary+HYBUnicodeReadable.m
@@ -1,0 +1,91 @@
+//
+//  NSDictionary+HYBUnicodeReadable.m
+//  demo
+//
+//  Created by huangyibiao on 15/12/29.
+//  Copyright © 2015年 huangyibiao. All rights reserved.
+//
+
+#import "NSDictionary+HYBUnicodeReadable.h"
+
+@implementation NSDictionary (HYBUnicodeReadable)
+
+#if DEBUG
+
+- (NSString *)descriptionWithLocale:(id)locale indent:(NSUInteger)level
+{
+    NSMutableString *desc = [NSMutableString string];
+    NSMutableString *tabString = [[NSMutableString alloc] initWithCapacity:level];
+    
+    for (NSUInteger i = 0; i < level; ++i) {
+        [tabString appendString:@"\t"];
+    }
+    
+    NSString *tab = (level > 0) ? tabString : @"";
+    
+    [desc appendString:@"{\n"];
+    
+    NSArray *allKeys = [self allKeys];
+    for (int i = 0; i < allKeys.count; i++)
+    {
+        id key = allKeys[i];
+        id obj = [self objectForKey:key];
+        
+        if ([obj isKindOfClass:[NSString class]])
+        {
+            (i == (allKeys.count-1)) ? [desc appendFormat:@"%@\t%@ = \"%@\"\n", tab, key, obj] : [desc appendFormat:@"%@\t%@ = \"%@\",\n", tab, key, obj];
+        }
+        else if ([obj isKindOfClass:[NSArray class]]
+                   || [obj isKindOfClass:[NSDictionary class]]
+                   || [obj isKindOfClass:[NSSet class]])
+        {
+            (i == (allKeys.count-1)) ? [desc appendFormat:@"%@\t%@ = %@\n", tab, key, [obj descriptionWithLocale:locale indent:level + 1]] :  [desc appendFormat:@"%@\t%@ = %@,\n", tab, key, [obj descriptionWithLocale:locale indent:level + 1]];
+        }
+        else if ([obj isKindOfClass:[NSData class]])
+        {
+            // 如果是NSData类型，尝试去解析结果，以打印出可阅读的数据
+            NSError *error = nil;
+            NSObject *result =  [NSJSONSerialization JSONObjectWithData:obj
+                                                                options:NSJSONReadingMutableContainers
+                                                                  error:&error];
+            // 解析成功
+            if (error == nil && result != nil)
+            {
+                if ([result isKindOfClass:[NSDictionary class]]
+                    || [result isKindOfClass:[NSArray class]]
+                    || [result isKindOfClass:[NSSet class]])
+                {
+                    NSString *str = [((NSDictionary *)result) descriptionWithLocale:locale indent:level + 1];
+                    (i == (allKeys.count-1)) ? [desc appendFormat:@"%@\t%@ = %@\n", tab, key, str] : [desc appendFormat:@"%@\t%@ = %@,\n", tab, key, str];
+                }
+                else if ([obj isKindOfClass:[NSString class]])
+                {
+                    (i == (allKeys.count-1)) ? [desc appendFormat:@"%@\t%@ = \"%@\"\n", tab, key, result] : [desc appendFormat:@"%@\t%@ = \"%@\",\n", tab, key, result];
+                }
+            }
+            else {
+                @try {
+                    NSString *str = [[NSString alloc] initWithData:obj encoding:NSUTF8StringEncoding];
+                    if (str != nil) {
+                        (i == (allKeys.count-1)) ? [desc appendFormat:@"%@\t%@ = \"%@\"\n", tab, key, str] : [desc appendFormat:@"%@\t%@ = \"%@\",\n", tab, key, str];
+                    } else {
+                        (i == (allKeys.count-1)) ? [desc appendFormat:@"%@\t%@ = %@\n", tab, key, obj] : [desc appendFormat:@"%@\t%@ = %@,\n", tab, key, obj];
+                    }
+                }
+                @catch (NSException *exception) {
+                    (i == (allKeys.count-1)) ? [desc appendFormat:@"%@\t%@ = %@\n", tab, key, obj] : [desc appendFormat:@"%@\t%@ = %@,\n", tab, key, obj];
+                }
+            }
+        } else {
+            (i == (allKeys.count-1)) ? [desc appendFormat:@"%@\t%@ = %@\n", tab, key, obj] : [desc appendFormat:@"%@\t%@ = %@,\n", tab, key, obj];
+        }
+    }
+    
+    [desc appendFormat:@"%@}", tab];
+    
+    return desc;
+}
+
+#endif
+
+@end

--- a/NSSet+HYBUnicodeReadable.h
+++ b/NSSet+HYBUnicodeReadable.h
@@ -1,0 +1,23 @@
+//
+//  NSSet+HYBUnicodeReadable.h
+//  demo
+//
+//  Created by huangyibiao on 15/12/29.
+//  Copyright © 2015年 huangyibiao. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+/*!
+ *  @author 黄仪标, 16-12-29 10:12:52
+ *
+ *  请不要删除作者信息
+ * 
+ *  @blog article http://www.henishuo.com/ios-unicode-readable/
+ *  @github https://github.com/CoderJackyHuang/HYBUnicodeReadable
+ *  @email huangyibiao520@163.com
+ *  @sinaweibo 标哥Jacky
+ */
+@interface NSSet (HYBUnicodeReadable)
+
+@end

--- a/NSSet+HYBUnicodeReadable.m
+++ b/NSSet+HYBUnicodeReadable.m
@@ -1,0 +1,92 @@
+//
+//  NSSet+HYBUnicodeReadable.m
+//  demo
+//
+//  Created by huangyibiao on 15/12/29.
+//  Copyright © 2015年 huangyibiao. All rights reserved.
+//
+
+#import "NSSet+HYBUnicodeReadable.h"
+
+@implementation NSSet (HYBUnicodeReadable)
+
+#if DEBUG
+
+- (NSString *)descriptionWithLocale:(id)locale indent:(NSUInteger)level
+{
+    NSMutableString *desc = [NSMutableString string];
+    
+    NSMutableString *tabString = [[NSMutableString alloc] initWithCapacity:level];
+    for (NSUInteger i = 0; i < level; ++i) {
+        [tabString appendString:@"\t"];
+    }
+    
+    NSString *tab = (level > 0) ? tabString : @"\t";
+    
+    [desc appendString:@"{(\n"];
+    
+    NSArray *tempArray = [self allObjects];
+    
+    for (int i = 0; i < tempArray.count; i++)
+    {
+        id obj = tempArray[i];
+        
+        if ([obj isKindOfClass:[NSDictionary class]]
+            || [obj isKindOfClass:[NSArray class]]
+            || [obj isKindOfClass:[NSSet class]])
+        {
+            NSString *str = [((NSDictionary *)obj) descriptionWithLocale:locale indent:level + 1];
+            (i == (tempArray.count-1)) ? [desc appendFormat:@"%@\t%@\n", tab, str] : [desc appendFormat:@"%@\t%@,\n", tab, str];
+        }
+        else if ([obj isKindOfClass:[NSString class]])
+        {
+            (i == (tempArray.count-1)) ? [desc appendFormat:@"%@\t\"%@\"\n", tab, obj] : [desc appendFormat:@"%@\t\"%@\",\n", tab, obj];
+        }
+        else if ([obj isKindOfClass:[NSData class]])
+        {
+            // 如果是NSData类型，尝试去解析结果，以打印出可阅读的数据
+            NSError *error = nil;
+            NSObject *result =  [NSJSONSerialization JSONObjectWithData:obj
+                                                                options:NSJSONReadingMutableContainers
+                                                                  error:&error];
+            // 解析成功
+            if (error == nil && result != nil)
+            {
+                if ([result isKindOfClass:[NSDictionary class]]
+                    || [result isKindOfClass:[NSArray class]]
+                    || [result isKindOfClass:[NSSet class]])
+                {
+                    NSString *str = [((NSDictionary *)result) descriptionWithLocale:locale indent:level + 1];
+                    (i == (tempArray.count-1)) ? [desc appendFormat:@"%@\t%@\n", tab, str] : [desc appendFormat:@"%@\t%@,\n", tab, str];
+                }
+                else if ([obj isKindOfClass:[NSString class]])
+                {
+                    (i == (tempArray.count-1)) ? [desc appendFormat:@"%@\t\"%@\"\n", tab, result] : [desc appendFormat:@"%@\t\"%@\",\n", tab, result];
+                }
+            }
+            else {
+                @try {
+                    NSString *str = [[NSString alloc] initWithData:obj encoding:NSUTF8StringEncoding];
+                    if (str != nil) {
+                        (i == (tempArray.count-1)) ? [desc appendFormat:@"%@\t\"%@\"\n", tab, str] : [desc appendFormat:@"%@\t\"%@\",\n", tab, str];
+                    } else {
+                        (i == (tempArray.count-1)) ? [desc appendFormat:@"%@\t%@\n", tab, obj] : [desc appendFormat:@"%@\t%@,\n", tab, obj];
+                    }
+                }
+                @catch (NSException *exception) {
+                    (i == (tempArray.count-1)) ? [desc appendFormat:@"%@\t%@\n", tab, obj] : [desc appendFormat:@"%@\t%@,\n", tab, obj];
+                }
+            }
+        } else {
+            (i == (tempArray.count-1)) ? [desc appendFormat:@"%@\t%@\n", tab, obj] : [desc appendFormat:@"%@\t%@,\n", tab, obj];
+        }
+    }
+    
+    [desc appendFormat:@"%@)}", tab];
+    
+    return desc;
+}
+
+#endif
+
+@end


### PR DESCRIPTION
美化打印结果，最后一个元素后面不出现逗号“，”，如下：
{
    hasBug = (
        "YES",
        "NO"
    ),
    dataString = "我是转换成",
    title = "http://www.henishuo.com",
    count = 11,
    results = {(
        "集合值2",
        "集合值1",
        {(
            "可变集合",
            "字典->不可变集合->可变集合",
            {
                key = "字典转成data",
                key1 = "在set、数组、字典中嵌套"
            }
        )}
    )},
    summaries = (
        "sm1",
        "sm2",
        {
            keysm = {
                stkey = "字典->数组->字典->字典"
            }
        },
        {
            key = "字典转成data",
            key1 = "在set、数组、字典中嵌套"
        }
    ),
    contact = (
        "关注博客地址：http://www.henishuo.com",
        "QQ群: 324400294",
        "关注微博：标哥Jacky",
        "关注GITHUB：CoderJackyHuang"
    ),
    name = "标哥的技术博客",
    parameters = {
        key1 = "value1",
        key13 = {
            key = "字典转成data",
            key1 = "在set、数组、字典中嵌套"
        },
        key2 = {
            key11 = "value11",
            key12 = (
                "三层",
                "字典->字典->数组"
            )
        }
    }
}
