### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 # HYBUnicodeReadable
 解决打印日志对于Unicode编码不能正常显示中文的问题，只需要将文件导入工程，不需要引用，就能达到打印日志显示Unicode编码中文数据
 
-#用途
+# 用途
 
 在开发中，通常希望在console中打印出的信息能够显示出Unicode编码对应的中文，由此作者研究了一下如何解决此问题。
 在这里，将此解决方案贡献给大家，如果觉得有用，请给个star!
 
-#安装使用
+# 安装使用
 
 支持cocoapods：
 
@@ -18,11 +18,11 @@ pod 'HYBUnicodeReadable', '~> 1.1'
 
 >注意：不需要引入头文件一样可以使用的！！！
 
-#效果图
+# 效果图
 
 ![image](https://github.com/CoderJackyHuang/HYBUnicodeReadable/blob/master/screenshot.gif)
 
-#version 1.0
+# version 1.0
 
 增加对NSData类型的数据的可视化打印，如下：
 
@@ -106,19 +106,19 @@ NSString *str = @"我是转换成data格式的字符串";
 }
 ```
 
-#Version1.1
+# Version1.1
 
 增加条件编译，只对Debug环境下起作用
 
-#讲解
+# 讲解
 
 为了更详细地说明如何使用，笔者写了一篇博文，大家可以阅读：[http://www.huangyibiao.com/ios-unicode-readable/](http://www.huangyibiao.com/ios-unicode-readable/)
 
-#维护
+# 维护
 
 笔者会一直维护，如果使用过程中出现任何bug，请反馈给作者，谢谢您的支持！！！
 
-#关注我
+# 关注我
 
 如果在使用过程中遇到问题，或者想要与我交流，可加入有问必答**QQ群：[324400294]()**
 
@@ -126,7 +126,7 @@ NSString *str = @"我是转换成data格式的字符串";
 
 关注新浪微博账号：[标哥Jacky](http://weibo.com/u/5384637337)
 
-#支持并捐助
+# 支持并捐助
 
 如果您觉得文章对您很有帮助，希望得到您的支持。您的捐肋将会给予我最大的鼓励，感谢您的支持！
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
